### PR TITLE
Enable clojurescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+out/

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,14 @@
   :url "https://github.com/weavejester/meta-merge"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :aliases {"test-all" ["with-profile" "default:+1.6" "test"]}
-  :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}})
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.189"]]
+  :plugins [[lein-cljsbuild "1.0.3"]
+            [lein-doo "0.1.6"]]
+  :aliases {"test-all" ["do" "clean," "test," "doo" "phantom" "test" "once"]}
+  :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+  :cljsbuild {:builds
+              {:test {:source-paths ["src" "test"]
+                      :compiler {:output-to "target/unit-test.js"
+                                 :main 'meta-merge.runner
+                                 :optimizations :simple}}}})

--- a/src/meta_merge/core.cljc
+++ b/src/meta_merge/core.cljc
@@ -1,11 +1,16 @@
 (ns meta-merge.core
   (:require [clojure.set :as set]))
 
+(defn- metadatable?
+  [obj]
+  #?(:clj (instance? clojure.lang.IObj obj)
+     :cljs ((some-fn coll? symbol?) obj)))
+
 (defn- meta*
   "Returns the metadata of an object, or nil if the object cannot hold
   metadata."
   [obj]
-  (if (instance? clojure.lang.IObj obj)
+  (if (metadatable? obj)
     (meta obj)
     nil))
 
@@ -13,7 +18,7 @@
   "Returns an object of the same type and value as obj, with map m as its
   metadata if the object can hold metadata."
   [obj m]
-  (if (instance? clojure.lang.IObj obj)
+  (if (metadatable? obj)
     (with-meta obj m)
     obj))
 

--- a/test/meta_merge/core_test.cljc
+++ b/test/meta_merge/core_test.cljc
@@ -1,6 +1,8 @@
 (ns meta-merge.core-test
-  (:require [clojure.test :refer :all]
-            [meta-merge.core :refer :all]))
+  (:require
+            #?(:clj  [clojure.test :refer :all]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [meta-merge.core :refer [meta-merge]]))
 
 (deftest test-meta-merge
   (testing "simple merge"

--- a/test/meta_merge/runner.cljs
+++ b/test/meta_merge/runner.cljs
@@ -1,0 +1,5 @@
+(ns meta-merge.runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [meta-merge.core-test]))
+
+(doo-tests 'meta-merge.core-test)


### PR DESCRIPTION
This enables clojurescript support. Tests all run (for me). I borrowed a metadatable? function from a util library I found which had clojurescript support.

Would it be worth considering removing direct dependencies on clojure & clojurescript? Then just requiring them in a :dev profile? This is something bidi has done so that you don't pull in unwanted dependencies that way, something to consider perhaps?