### PR TITLE
Switch to circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+test:
+  override:
+    - LEIN_JAVA_CMD=/usr/lib/jvm/jdk1.8.0/bin/java lein trampoline test
+    - LEIN_JAVA_CMD=/usr/lib/jvm/jdk1.8.0/bin/java lein test-cljs
+    - LEIN_JAVA_CMD=/usr/lib/jvm/jdk1.7.0/bin/java lein trampoline test
+    - LEIN_JAVA_CMD=/usr/lib/jvm/jdk1.7.0/bin/java lein test-cljs


### PR DESCRIPTION
You may have noticed that as of the switch to Reader Conditionals, Travis no longer runs the tests in the cljc file. This is caused by an outdated leiningen version in the travis cookbook, https://github.com/travis-ci/travis-ci/issues/4791 See here: https://travis-ci.org/weavejester/meta-merge/jobs/99039149 on the jvm, 0 tests are run.

Compare this with my fork + circleci: https://circleci.com/gh/SevereOverfl0w/meta-merge/9

circleci is also built on Clojure, so it feels good to support our fellows.
