### PR TITLE
Support removing keys entirely

### DIFF
--- a/src/meta_merge/core.cljc
+++ b/src/meta_merge/core.cljc
@@ -46,6 +46,11 @@
     obj
     (vary-meta obj dissoc :top-displace)))
 
+(defn- remove?
+  "Returns true if the key-value-pair is marked for removal"
+  [kvp]
+  (-> kvp val meta* :remove))
+
 (defn- pick-prioritized
   "Picks the highest prioritized element of left and right and merge their
   metadata."
@@ -86,7 +91,10 @@
          (pick-prioritized left right)
 
          (and (map? left) (map? right))
-         (merge-with meta-merge left right)
+         (let [right-meta (meta* right)
+               merged     (cond-> (merge-with meta-merge left right)
+                            right-meta (with-meta* right-meta))]
+           (into (empty merged) (remove remove?) merged))
 
          (and (set? left) (set? right))
          (set/union right left)

--- a/test/meta_merge/core_test.cljc
+++ b/test/meta_merge/core_test.cljc
@@ -54,4 +54,13 @@
     (is (= (meta-merge {:a :b :x 1} {:a :c :y 2} {:a :d})
            {:a :d :x 1 :y 2}))
     (is (= (meta-merge {:a :b :x 1} {:a :c :y 2} {:a :d} {:y 4 :z 3})
-           {:a :d :x 1 :y 4 :z 3}))))
+           {:a :d :x 1 :y 4 :z 3})))
+
+  (testing "meta remove"
+    (is (= {:b 2} (meta-merge {:a 1 :b 2} {:a ^:remove []})))
+    (is (= {:a {:c 3}} (meta-merge {:a {:b {} :c 3}} {:a {:b ^:remove {}}})))
+    (is (= {:a 1 :b 20 :c {:f 6}}
+         (meta-merge {:a 1 :b 2 :c {:d 4 :e 5}}
+                     {:b ^:remove []}
+                     {:b 20 :c ^:remove {}}
+                     {:c {:f 6}})))))


### PR DESCRIPTION
Sometimes I find it useful to be able to define a removal of a key-value-pair.

Example: an app contains some base Integrant configuration in its uberjar, which is then merged with an environment-specific one to produce an effective config. If I want to completely remove one integrant component (so that even its namespace isn't loaded) from the configuration, I need something like this.

Encouraged by [this Slack thread](https://clojurians.slack.com/archives/C0CFGN25D/p1699622758159309) I decided to submit a port of the algo I implemented for work, inspired by this project.

Suggestions are welcome.